### PR TITLE
Open R2 downloader readme in a separate tab

### DIFF
--- a/central/shared-content.html
+++ b/central/shared-content.html
@@ -10,7 +10,7 @@
     <br>
     <p><strong>Quick Start:</strong> Copy one of the commands below and run it in your terminal to download the indicated dataset. The downloader works on Linux, macOS, and Windows (WSL/Cygwin).</p>
     
-    <p>For more information about the MLC R2 Downloader, please see the <a href="https://github.com/mlcommons/r2-downloader/blob/main/README.md">README</a> on GitHub.</p>
+    <p>For more information about the MLC R2 Downloader, please see the <a href="https://github.com/mlcommons/r2-downloader/blob/main/README.md" target="_blank">README</a> on GitHub.</p>
 
     <details>
         <summary><strong>Windows Cygwin Setup</strong> (click to expand)</summary>


### PR DESCRIPTION
This change would open the GitHub repo in a separate preventing users from clicking back button to go back to the instruction page.
