### PR TITLE
Add information about container image to quickstart

### DIFF
--- a/central/shared-content.html
+++ b/central/shared-content.html
@@ -8,9 +8,9 @@
 <!-- Quick Start section - loaded separately at the top of pages -->
 <div id="quick-start-section">
     <br>
-    <p><strong>Quick Start:</strong> Copy one of the commands below and run it in your terminal to download the indicated dataset. The downloader works on Linux, macOS, and Windows (WSL/Cygwin).</p>
+    <p><strong>Quick Start:</strong> Copy one of the commands below and run it in your terminal to download the indicated dataset. The downloader works on Linux, macOS, and Windows (WSL/Cygwin). We also distribute a container image with all MLC R2 Downloader dependencies, as well as the latest version of the script, pre-installed. You can pull the image from <a href="https://ghcr.io/mlcommons/r2-downloader:latest" target="_blank">ghcr.io/mlcommons/r2-downloader:latest</a>.</p>
     
-    <p>For more information about the MLC R2 Downloader, please see the <a href="https://github.com/mlcommons/r2-downloader/blob/main/README.md" target="_blank">README</a> on GitHub.</p>
+    <p>For more information about the MLC R2 Downloader, the container image, and usage, please see the <a href="https://github.com/mlcommons/r2-downloader/blob/main/README.md" target="_blank">README</a> on GitHub.</p>
 
     <details>
         <summary><strong>Windows Cygwin Setup</strong> (click to expand)</summary>


### PR DESCRIPTION
In support of the [newly added](https://github.com/mlcommons/r2-downloader/pull/21) r2-downloader [container image](https://github.com/mlcommons/r2-downloader/pkgs/container/r2-downloader).